### PR TITLE
Fix too large tasks query

### DIFF
--- a/notebooks/tasks.ipynb
+++ b/notebooks/tasks.ipynb
@@ -214,6 +214,26 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"\"\"\n",
+    "SELECT taskID, count(*) FROM `modules_with_context`\n",
+    "WHERE yearID = :year_id\n",
+    "GROUP BY taskID;\n",
+    "\"\"\"\n",
+    "\n",
+    "modules_per_task = {\n",
+    "    task: module_count\n",
+    "    for (task, module_count) in session.execute(query, {\"year_id\": current_year.id})\n",
+    "}\n",
+    "\n",
+    "# modules_per_task"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -249,6 +269,7 @@
     "                    no_evaluations_avg[task] if task in no_evaluations_avg else '-',\n",
     "                    no_evaluations_median[task] if task in no_evaluations_median else '-',\n",
     "                    sorted(no_evaluations_dict[task])[-5:] if task in no_evaluations_dict else '-',\n",
+    "                    modules_per_task[task.id] if task.id in modules_per_task else 0\n",
     "                )\n",
     "            )\n",
     "        except Exception as e:\n",
@@ -268,6 +289,7 @@
     "        'Average N.O. Evaluations Per User',\n",
     "        'Median N.O. Evaluations Per User',\n",
     "        'Some Maximum Evaluations Counts',\n",
+    "        'Number of modules'\n",
     "    ]).set_index('Task')\n",
     "    \n",
     "    s = df.style\n",
@@ -287,7 +309,7 @@
     "    )\n",
     "    \n",
     "    s.background_gradient(\n",
-    "        subset=['Discussion Posts Count'],\n",
+    "        subset=['Discussion Posts Count', 'Number of modules'],\n",
     "        cmap=sns.light_palette(\"orange\", as_cmap=True)\n",
     "    )\n",
     "    \n",

--- a/notebooks/tasks.ipynb
+++ b/notebooks/tasks.ipynb
@@ -92,35 +92,44 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"\"\"\n",
+    "SELECT taskID, count(*) as participants_count FROM (\n",
+    "    SELECT user, taskID, ok, count(*) as participant_evals_count\n",
+    "    FROM `evaluations_participants_with_context`\n",
+    "    WHERE yearID = :year_id AND ok = 0\n",
+    "    GROUP BY user, taskID, ok\n",
+    "    HAVING count(*) > :at_least_failed_attempts\n",
+    ") as k\n",
+    "GROUP BY taskID;\n",
+    "\"\"\"\n",
+    "\n",
+    "# result = session.execute(query, {\"year_id\": 16, \"at_least_failed_attempts\": 10})\n",
+    "\n",
+    "# for row in result:\n",
+    "#     print(row)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "per_module = session.query(\n",
-    "    model.Evaluation.user.label('user_id'),\n",
-    "    func.count(model.Evaluation.id).label('eval_count'),\n",
-    ").\\\n",
-    "    join(model.Evaluation.r_module).join(model.Module.r_task).\\\n",
-    "    join(model.Task.r_wave).\\\n",
-    "    filter(model.Wave.year == current_year.id).\\\n",
-    "    group_by(model.Evaluation.user,\n",
-    "             model.Evaluation.module).subquery()\n",
-    "\n",
     "EVAL_LIMITS = [10, 30, 50]\n",
     "problematic_tasks = {\n",
     "    limit: {\n",
     "        task: evals_count\n",
-    "        for (task, evals_count) in (\n",
-    "            evaluations.\n",
-    "            filter(model.Evaluation.ok == False).\n",
-    "            join(per_module, per_module.c.user_id == model.User.id).\\\n",
-    "            group_by(model.Task.id).\\\n",
-    "            filter(per_module.c.eval_count > limit).all()\n",
-    "        )\n",
+    "        for (task, evals_count) in session.execute(query, {\"year_id\": current_year.id, \"at_least_failed_attempts\": limit})\n",
     "    }\n",
     "    for limit in EVAL_LIMITS\n",
-    "}\n"
+    "}\n",
+    "\n",
+    "# problematic_tasks"
    ]
   },
   {
@@ -233,9 +242,9 @@
     "                    successful_evaluations_d[task],\n",
     "                    successful_evaluations_d[task] / evaluations_per_task_d[task],\n",
     "                    evaluations_per_task_d[task]-successful_evaluations_d[task],\n",
-    "                    problematic_tasks[10][task] if task in problematic_tasks[10] else 0,\n",
-    "                    problematic_tasks[30][task] if task in problematic_tasks[30] else 0,\n",
-    "                    problematic_tasks[50][task] if task in problematic_tasks[50] else 0,\n",
+    "                    problematic_tasks[10][task.id] if task.id in problematic_tasks[10] else 0,\n",
+    "                    problematic_tasks[30][task.id] if task.id in problematic_tasks[30] else 0,\n",
+    "                    problematic_tasks[50][task.id] if task.id in problematic_tasks[50] else 0,\n",
     "                    posts_count_dict[task] if task in posts_count_dict else 0,\n",
     "                    no_evaluations_avg[task] if task in no_evaluations_avg else '-',\n",
     "                    no_evaluations_median[task] if task in no_evaluations_median else '-',\n",
@@ -430,7 +439,7 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -444,7 +453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.14"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The original query generated by SQLAlchemy ORM was producing too large temporary tables which was killing the build.
I've replaced it with a native SQL query doing the same thing using an existing db view.

Note: Maybe we should move the documentation for them from the [admin repository](https://github.com/fi-ksi/admin-stuff/blob/master/db_views.sql)?

I've also added information about number of modules per task, as it's important for correct interpretation of the table.


---- 

### Technical details

The new query for stats of tasks looks like this: 

```sql
SELECT taskID, count(*) as participants_count FROM (
    SELECT user, taskID, ok, count(*) as participant_evals_count
    FROM `evaluations_participants_with_context`
    WHERE yearID = :year_id AND ok = 0
    GROUP BY user, taskID, ok
    HAVING count(*) > :at_least_failed_attempts
) as k
GROUP BY taskID;
```


For reference, I'm adding the original query:

```sql
SELECT 
  tasks.id AS tasks_id, 
  tasks.title AS tasks_title, 
  tasks.author AS tasks_author, 
  tasks.co_author AS tasks_co_author, 
  tasks.wave AS tasks_wave, 
  tasks.prerequisite AS tasks_prerequisite, 
  tasks.intro AS tasks_intro, 
  tasks.body AS tasks_body, 
  tasks.solution AS tasks_solution, 
  tasks.thread AS tasks_thread, 
  tasks.picture_base AS tasks_picture_base, 
  tasks.time_created AS tasks_time_created, 
  tasks.time_deadline AS tasks_time_deadline, 
  tasks.evaluation_public AS tasks_evaluation_public, 
  tasks.git_path AS tasks_git_path, 
  tasks.git_branch AS tasks_git_branch, 
  tasks.git_commit AS tasks_git_commit, 
  tasks.deploy_date AS tasks_deploy_date, 
  tasks.deploy_status AS tasks_deploy_status, 
  tasks.eval_comment AS tasks_eval_comment, 
  count(DISTINCT users.id) AS evals_count 
FROM 
  tasks 
  INNER JOIN waves ON waves.id = tasks.wave 
  INNER JOIN modules ON tasks.id = modules.task 
  INNER JOIN evaluations ON evaluations.module = modules.id 
  INNER JOIN users ON users.id = evaluations.user 
  INNER JOIN (
    SELECT 
      evaluations.user AS user_id, 
      count(evaluations.id) AS eval_count 
    FROM 
      evaluations 
      INNER JOIN modules ON modules.id = evaluations.module 
      INNER JOIN tasks ON tasks.id = modules.task 
      INNER JOIN waves ON waves.id = tasks.wave 
    WHERE 
      waves.year = % s 
    GROUP BY 
      evaluations.user, 
      evaluations.module
  ) AS anon_1 ON anon_1.user_id = users.id 
WHERE 
  waves.year = % s 
  AND users.`role` = % s 
  AND evaluations.ok = false 
  AND anon_1.eval_count > % s 
GROUP BY 
  tasks.id
```


